### PR TITLE
Excluded Chatters

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -199,18 +199,40 @@ function startListening() {
     });
 
     client.on('message', (wat, tags, message, self) => {
-      const badges = tags.badges || {};
-      const isBroadcaster = badges.broadcaster;
-      const isMod = badges.moderator;
-      if(document.getElementById('modsonly').checked) {
-        if(isBroadcaster || isMod ) {
-          new TTS(message, tags);
-        }
-      }
-      else {
-        new TTS(message, tags); 
-      }
+      manageOptions(tags, message);
     });
+  }
+}
+
+function manageOptions(tags, message) {
+  const badges = tags.badges || {};
+  const isBroadcaster = badges.broadcaster;
+  const isMod = badges.moderator;
+
+  const excludedchatterstextarea = document.getElementById('excluded-chatters');
+  var lines = excludedchatterstextarea.value.split('\n');
+  var lines = lines.map(line => line.toLowerCase());
+
+  if(document.getElementById('modsonly').checked) {
+    if(isBroadcaster || isMod ) {
+      new TTS(message, tags);
+      return;
+    }
+  }
+  if(document.getElementById('exclude-toggle').checked) {
+    console.log(lines);
+    if(lines.includes(tags['display-name'].toLowerCase())) {
+      return;
+    }
+    else {
+      new TTS(message, tags);
+      console.log('not in lines');
+      return;
+    }
+  }
+  else {
+    new TTS(message, tags); 
+    return;
   }
 }
 

--- a/public/app.js
+++ b/public/app.js
@@ -291,3 +291,27 @@ if(urlParams.get('channelname') !== null) {
 window.speechSynthesis.onvoiceschanged = function() {
   populateVoiceList();
 }
+
+/*
+  If the checkbox is selected to exclude chatters, show the options for it.
+*/
+document.getElementById("exclude-toggle").addEventListener("change", function() {
+  var options = document.getElementById('exclude-options');
+  if(this.checked == true) {
+    options.classList.remove('d-none');
+  }
+  if(this.checked == false) {
+    options.classList.add('d-none');
+  }
+});
+
+/*
+  Fills in the excluded chatters list with a predefined list of known moderation bots
+*/
+function fillInBots() {
+  var excludedChatters = document.getElementById("excluded-chatters");
+  excludedChatters.value = "Nightbot\nMoobot\nStreamElements\nStreamlabs\nFossabot";
+}
+
+
+

--- a/public/index.html
+++ b/public/index.html
@@ -112,7 +112,24 @@
               <div class="col-6">
                 <input id="announcechatter" type="checkbox" />
               </div>
-            </div>            
+            </div>   
+            <div class="row">
+              <div class="col-6">
+                <label for="exclude"><small>Exclude Certain Chatters</small></label>
+              </div>
+              <div class="col-6">
+                <input id="exclude-toggle" type="checkbox" />
+              </div>
+            </div>    
+            <div class="row d-none" id="exclude-options">
+              <div class="col-6">
+                <small>Please enter the chatters you would like to exclude in the box on the right, making a new line for each chatter.</small>
+                <button class="btn btn-outline-primary" onclick="fillInBots()">Start with Known Bots</button>
+              </div>
+              <div class="col-6">
+                <textarea id="excluded-chatters" rows="10" class="form-control" placeholder="XQC&#10;BagofChaos"></textarea>
+              </div>
+            </div>                    
             <div class="row">
               <div class="col-12">
               <small><i>Note: Amazon Polly integration is a very early work in progress. Messages sent will <a

--- a/public/index.html
+++ b/public/index.html
@@ -185,7 +185,7 @@
           </button>
         </div>
         <div class="modal-body">
-          <p>Below is a url you can place as a browser source into OBS. This URL will auto apply your channel name and start listening for messages.</p><p>Note that only Amazon Polly is supported as a browser source for OBS.</p>
+          <p>Below is a url you can place as a browser source into OBS. This URL will auto apply your channel name and start listening for messages.</p><p>Note that only Amazon Polly is supported as a browser source for OBS, and that excluded chatters does not work (yet).</p>
           <div class="row">
             <div class="col-8">
             <input id="settingsURL" class="form-control" value="" disabled />


### PR DESCRIPTION
Allows a user to enter a list of excluded chatters that will not be read by the TTS bot. 

Note that this does not work with exporting a URL as a web source into OBS (yet). 