### PR TITLE
Added an Exclude Bot Commands filter

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -169,6 +169,9 @@ function manageOptions(tags, message) {
   var lines = excludedchatterstextarea.value.split('\n');
   var lines = lines.map(line => line.toLowerCase());
 
+  if(document.getElementById('nocommands').checked && message.startsWith("!")) {
+    return;
+  }
   if(document.getElementById('modsonly').checked) {
     if(isBroadcaster || isMod ) {
       new TTS(message, tags);

--- a/public/index.html
+++ b/public/index.html
@@ -122,6 +122,14 @@
               <div class="col-6">
                 <textarea id="excluded-chatters" rows="10" class="form-control" placeholder="XQC&#10;BagofChaos"></textarea>
               </div>
+            </div>
+            <div class="row">
+              <div class="col-6">
+                <label for="nocommands"><small>Exclude Bot Commands</small></label>
+              </div>
+              <div class="col-6">
+                <input id="nocommands" type="checkbox" />
+              </div>
             </div>                    
             <div class="row">
               <button class="btn btn-dark mt-3 ml-2" data-toggle="modal" data-target="#settingsModal" onclick="exportSettings()">Export Channel to URL</button>


### PR DESCRIPTION
Very simple bot command filter. I just have it checking if a message starts with `!` which could easily be expanded to be configurable if necessary.